### PR TITLE
update the regex to only use project names

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -15,7 +15,7 @@ destinations:
       - '"High disk usage detected"'
   - name: SHIPWRECKED
     regex:
-      - \*\*Project:\*\* graham@shipwrecked\\n
-      - \*\*Project:\*\* dev@shipwrecked-redirect\\n
-      - \*\*Project:\*\* dev@shipwrecked-profile-generator\\n
+      - graham@shipwrecked
+      - dev@shipwrecked-redirect
+      - dev@shipwrecked-profile-generator
 


### PR DESCRIPTION
The previous regex did not match the projects. This PR simplifies the regex to match any webhooks that contains the matching project names. 